### PR TITLE
list all other guss files, and some styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,21 +1,40 @@
 <html>
   <head>
+    <title>GUSS</title>
+    <link href='http://fonts.googleapis.com/css?family=Lato:300,400,900,400italic' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" type="text/css" href="/static/css/site.css" />
   </head>
   <body>
-    <a id="build" href="/">Build a new gus</a>
-  <script type="text/javascript" src="static/js/auth.js"></script>
-  <script>
-    /*
-    **
-    **  entry point is a callback to retrieving gapi library
-    **  see <script src="https://apis.google.com/js/client.js?onload=init_app"> above
-    **
-    */
-    function init_app () {
-        window.App = window.App || {};
-        App.guss = new App.GussController();       
-    };
-  </script>
+    <header class="header cf">
+      <div class="container">
+        <h1>GUSS</h1>
+      </div>
+    </header>
+    <div class="container cf">
+      <a id="build" class="btn orange" href="/">Build a new gus</a>
+      <div id="gus-info"></div>
+    </div>
+
+
+
+
+
+
+
+
+    <script type="text/javascript" src="static/js/auth.js"></script>
+    <script>
+      /*
+      **
+      **  entry point is a callback to retrieving gapi library
+      **  see <script src="https://apis.google.com/js/client.js?onload=init_app"> above
+      **
+      */
+      function init_app () {
+          window.App = window.App || {};
+          App.guss = new App.GussController();       
+      };
+    </script>
   <script src="https://apis.google.com/js/client.js?onload=init_app"></script>
   </body>
 </html>

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -1,0 +1,77 @@
+body {
+  margin:0;
+  padding:0;
+  background:#f6f6f6;
+  font-family: 'Lato', sans-serif;
+}
+.cf:before, .cf:after { content:" "; display:table; }
+.cf:after { clear:both; }
+.cf { *zoom:1; }
+
+a { text-decoration: none; }
+.btn {
+  background:#666;
+  color:white;
+  text-transform:uppercase;
+  font-size:0.9em;
+  font-weight:100;
+  letter-spacing: 0.1em;
+  padding:1em 1.5em;
+  border-radius:5px;
+  box-shadow:2px 2px 0px 1px #888;
+}
+.btn.blue {
+  background:#6a9bc3;
+  color:#2a4e6c;
+  box-shadow:2px 2px 0px 1px #3f75a2;
+}
+.btn.orange {
+  background:#F2BC57;
+  color:white;
+  box-shadow:2px 2px 0px 1px #CFA04A;
+}
+.container {
+  margin:auto;
+  width:800px;
+}
+.header {
+  width:100%;
+  background:#0367A6;
+  padding:100px 0 20px;
+  margin-bottom:40px;
+}
+.header h1 {
+  margin:0;
+  font-weight:400;
+  font-size:5em;
+  color:white;
+  text-shadow:1px 1px 1px rgba(0,0,0,0.8);
+  float:left;
+}
+
+#gus-list {
+  list-style-type: none;
+  margin:40px 0 0;
+  padding:0;
+}
+.gus-item {
+  margin-bottom: 15px;
+  font-weight: 900;
+  float: left;
+  width: 42%;
+  padding: 1em;
+  margin-right: 15px;
+  background: white;
+}
+.gus-item:hover { background:#A6242F; }
+.gus-item:hover a { color:white; }
+.gus-item a {
+  color:#666;
+}
+.gus-item-id,
+.gus-item-date {
+  font-size:0.8em;
+}
+.gus-item-id {
+  font-weight:100;
+}

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -41,7 +41,7 @@ GussController.prototype.bind_event_listeners = function() {
     // build new gus click event
     document.getElementById('build').addEventListener('click', function(e) {
 
-        console.log( "[ CLICK EVENT ]" );
+        console.log( "[ CLICK EVENT: build gus ]" );
         e.preventDefault();
 
         /* 
@@ -195,38 +195,106 @@ GussController.prototype.qc_access_token = function( token_object ) {
 
 };
 
-
+/*
+**
+**  here the app queries your drive for files (includes folders)
+**  with the name containing 'gus', isn't in the trash and is of
+**  MIME Type 'folder'... application/vnd.google-apps.folder.
+**  If the result returns as 0, then a new folder is created with 
+**  createFolder() - and subsequently creates a new gus file with
+**  the blob. If the folder exists, a new file will be created within
+**  that folder.
+**
+*/
 GussController.prototype.get_or_insert_spreadsheet = function() {
 
-        gapi.client.request({
-            'path': '/drive/v2/files',
-            'method': 'GET',
-            'params': { 
-                q : "title contains 'gus' and mimeType = 'application/vnd.google-apps.folder' and trashed = false" ,
-                maxResults : "1000" ,
-                access_token : this.access_token 
-            },
-        })
-        .then( 
-            function ( response ) {
-                // if no gus folder, create one and add file
-                if ( response.result.items.length === 0 ) {
-                    console.log( "[ NO EXISTING FOLDER ]: creating..." );
-                    // this.createFolder().then(this.insert_file());
-                    this.createFolder();
-                }
-                // otherwise, create a new file within the gus folder id
-                else {
-                    console.log( "[ FOUND FOLDER ]: there are", response.result.items.length, "existing folders:" , response.result.items  );
-                    this.folderID = response.result.items[0].id;
-                    this.insert_file();
-                }
-            }.bind( this ) ,
-            function ( e ) {
-                // error
-                console.error( "[ ERROR ]: error in listing files ", e ); 
-        });
+  gapi.client.request({
+    'path': '/drive/v2/files',
+    'method': 'GET',
+    'params': { 
+      q : "title contains 'gus' and mimeType = 'application/vnd.google-apps.folder' and trashed = false" ,
+      maxResults : "1000" ,
+      access_token : this.access_token 
+    },
+  })
+  .then( 
+      function ( response ) {
+          // if no gus folder, create one and add file
+          if ( response.result.items.length === 0 ) {
+              console.log( "[ NO EXISTING FOLDER ]: creating..." );
+              // this.createFolder().then(this.insert_file());
+              this.createFolder(this);
+          }
+          // otherwise, create a new file within the gus folder id
+          else {
+              console.log( "[ FOUND FOLDER ]: there are", response.result.items.length, "existing folders:" , response.result.items  );
+              this.folderID = response.result.items[0].id;
+              this.insert_file();
+              this.show_other_gus_files( this.folderID );
+          }
+      }.bind( this ) ,
+      function ( e ) {
+          // error
+          console.error( "[ ERROR ]: error in listing files ", e ); 
+  });
 };
+
+
+GussController.prototype.show_other_gus_files = function( folder ) {
+  
+  console.log(" [ SEARCHING FOR GUS FILES ] in folder id: " + folder);
+
+  gapi.client.request({
+    'path': '/drive/v2/files/' + folder + '/children',
+    'method': 'GET',
+    'params': {
+      access_token : this.access_token
+    },
+  })
+  .then(
+    function ( response ) {
+      console.log( "[ SUCCESS ]: found", response.result.items.length, "existing GUS files", response.result.items );
+      // create unordered list of other gus files
+      var gusList = document.createElement('ul');
+      gusList.id = 'gus-list';
+      // show metadata of each file
+      for(var i=0; i<response.result.items.length; i++){
+
+        gapi.client.request({
+          'path': '/drive/v2/files/' + response.result.items[i].id,
+          'method': 'GET',
+          'params': {
+            access_token: this.access_token
+          }
+        })
+        .then(
+          function ( file ) {
+            console.log( file );
+            var f = file.result;
+            var d = new Date(f.createdDate);
+            var date = d.getHours() + ':' + d.getMinutes() + ':' + d.getSeconds() + ' ' + d.getMonth() + '/' + d.getDate() + '/' + d.getFullYear();
+            var gusItem = document.createElement('li');
+            gusItem.className = 'gus-item';
+            gusItem.innerHTML = '<a href="'+f.alternateLink+'">'+f.title+'<br><span class="gus-item-id">'+f.id+'</span><br><span class="gus-item-date">Created: '+date+'</span></a>';
+            gusList.appendChild(gusItem);
+          }.bind( this ),
+          function ( e ) {
+            // error
+            console.error( "[ ERROR ]: cannot get single file information" );
+          }
+        )
+
+      }
+
+      document.getElementById('gus-info').appendChild(gusList);
+
+    }.bind( this ),
+    function ( e ) {
+      // error
+      console.error( "[ ERROR ]: cannot list other gus files" );
+    }
+  );
+}
 
 GussController.prototype.insert_file = function( ) {
     console.log( "[ INSERT_FILE ]" );
@@ -275,7 +343,7 @@ GussController.prototype.insert_file = function( ) {
         .then( 
             function( file ) {
                 // success
-                console.log( "[ SUCCESS ]: file created => ", file ); 
+                console.log( "[ SUCCESS ]: file created => ", file );
             } ,
             function() {
                 // error
@@ -306,7 +374,7 @@ GussController.prototype.createFolder = function( ) {
        console.log( "[ CREATED FOLDER ] : " + resp.id );
        this.folderID = resp.id; // this doesn't seem to be working ... no access to this within the execute scope?
        this.insert_file();
-   });
+   }.bind( this ));
 };
 
 


### PR DESCRIPTION
Greg, I've added a new function to list all of the files and some of their data when someone builds a new spreadsheet. I've also added some preliminary styles, found in `static/css/site.css` so we don't have to stare at this blank page any more :dancer: 

![screen shot 2014-12-13 at 10 21 44 am](https://cloud.githubusercontent.com/assets/1943001/5424735/1b03c966-82b2-11e4-8fd8-9806304e3df1.png)

I don't think this is the best route to go in terms of functionality - I guess I'd like to see two buttons instead of one. One would be the current "build new guss" - the second would be "view all guss documents" since the only way to view the docs is by creating another document.
### `show_other_gus_files()`

The new function `show_other_gus_files()` isn't terribly elegant, since it makes a unique call to the `gapi` for every single item, since the `'path': '/drive/v2/files/' + folder + '/children'` for returning all of those files only returns the `id` and not the file name. Could we request more information to be returned with that?
